### PR TITLE
fixes #45 encode/decode the filepath correctly

### DIFF
--- a/bin/src/model/dto/config/cached_package.dart
+++ b/bin/src/model/dto/config/cached_package.dart
@@ -5,7 +5,7 @@ import 'package:meta/meta.dart';
 @immutable
 class CachedPackage {
   final String name;
-  final String rootUri;
+  final Uri rootUri;
   final String packageUri;
 
   const CachedPackage({
@@ -24,7 +24,7 @@ class CachedPackage {
     }
     return CachedPackage(
       name: json['name'] as String,
-      rootUri: rootUri,
+      rootUri: Uri.parse(rootUri),
       packageUri: json['packageUri'] as String,
     );
   }

--- a/bin/src/repo/license_repository.dart
+++ b/bin/src/repo/license_repository.dart
@@ -90,7 +90,8 @@ class LicenseRepository {
     );
   }
 
-  static String? _guessLocalLicenseFile(String packagePath) {
+  static String? _guessLocalLicenseFile(Uri packagePathUri) {
+    final packagePath = packagePathUri.toFilePath();
     if (packagePath.isNotEmpty) {
       final packageFolder = Directory(packagePath);
       if (!packageFolder.existsSync()) {


### PR DESCRIPTION
* when using caching repository servers with sub paths for some reason the encoding/decoding is off, so that the license generator is not finding the cached packages anymore.

fixes #45 